### PR TITLE
Add FXMacroData integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ coverage run -m pytest
 coverage report -m
 ```
 
+## FXMacroData macro context
+
+`FXMacroDataClient` uses the canonical `https://api.fxmacrodata.com/v1/` API host.
+Set `FXMACRODATA_API_KEY` (or `FXMD_API_KEY`) to access protected data, or pass
+`api_key` directly when creating the client. `build_macro_context("EUR", "USD")`
+returns the pair's catalogue, filtered release calendars and announcements, and FX data.
+
 ## Output
 
 The output its a dictionary. The summary is a summary all the inputs and of the performace of the model. The df is a Pandas Dataframe, which contains all of the data used in the simulation. And the `trade_df` is a subset of the `df` frame which just has all the rows when there was an event. The `backtest` object is also returned, with the details of how the backtest was run.

--- a/fast_trade/__init__.py
+++ b/fast_trade/__init__.py
@@ -4,5 +4,6 @@ from .finta import TA
 from .run_backtest import run_backtest
 from .transformers_map import transformers_map
 from .validate_backtest import validate_backtest
+from .fxmacrodata import FXMacroDataClient, build_macro_context
 
 # from .calculate_perc_missing import calculate_perc_missing

--- a/fast_trade/fxmacrodata.py
+++ b/fast_trade/fxmacrodata.py
@@ -1,0 +1,137 @@
+import json
+import os
+from typing import Any, Dict, Mapping, Optional
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+Params = Mapping[str, Any]
+
+
+class FXMacroDataClient:
+    """REST client for macro, FX, COT, commodity, and session data."""
+
+    DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1/"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: int = 30,
+    ) -> None:
+        self.api_key = (
+            api_key
+            or os.getenv("FXMACRODATA_API_KEY")
+            or os.getenv("FXMD_API_KEY")
+            or ""
+        )
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout = timeout
+
+    def request(
+        self,
+        path: str,
+        params: Optional[Params] = None,
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        query = dict(params or {})
+        if self.api_key:
+            query["api_key"] = self.api_key
+        url = urllib.parse.urljoin(self.base_url, path.lstrip("/"))
+        if query:
+            url = url + "?" + urllib.parse.urlencode(query)
+
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout or self.timeout) as resp:
+                payload = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"FXMacroData request failed with HTTP {exc.code}: {body}"
+            ) from exc
+        return json.loads(payload)
+
+    def data_catalogue(self, currency: str) -> Dict[str, Any]:
+        return self.request(f"data_catalogue/{currency.lower()}")
+
+    def announcements(
+        self, currency: str, indicator: str, **params: Any
+    ) -> Dict[str, Any]:
+        return self.request(
+            f"announcements/{currency.lower()}/{indicator}",
+            params,
+        )
+
+    def latest_announcements(self, currency: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"announcements/{currency.lower()}/latest", params)
+
+    def calendar(self, currency: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"calendar/{currency.lower()}", params)
+
+    def predictions(
+        self, currency: str, indicator: str, **params: Any
+    ) -> Dict[str, Any]:
+        return self.request(f"predictions/{currency.lower()}/{indicator}", params)
+
+    def forex(self, base: str, quote: str = "usd", **params: Any) -> Dict[str, Any]:
+        return self.request(f"forex/{base.lower()}/{quote.lower()}", params)
+
+    def cot(self, currency: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"cot/{currency.lower()}", params)
+
+    def commodity(self, indicator: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"commodities/{indicator}", params)
+
+    def commodities_latest(self, **params: Any) -> Dict[str, Any]:
+        return self.request("commodities/latest", params)
+
+    def rate_differentials(
+        self, base: str, quote: str = "usd", **params: Any
+    ) -> Dict[str, Any]:
+        return self.request(
+            f"rate_differentials/{base.lower()}/{quote.lower()}",
+            params,
+        )
+
+    def forward_differentials(
+        self, base: str, quote: str = "usd", **params: Any
+    ) -> Dict[str, Any]:
+        return self.request(
+            f"forward_differentials/{base.lower()}/{quote.lower()}",
+            params,
+        )
+
+    def market_sessions(self, **params: Any) -> Dict[str, Any]:
+        return self.request("market_sessions", params)
+
+    def risk_sentiment(self, **params: Any) -> Dict[str, Any]:
+        return self.request("risk_sentiment", params)
+
+    def news(self, currency: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"news/{currency.lower()}", params)
+
+    def press_releases(self, currency: str, **params: Any) -> Dict[str, Any]:
+        return self.request(f"press-releases/{currency.lower()}", params)
+
+
+def build_macro_context(
+    base: str,
+    quote: str = "usd",
+    indicator: str = "policy_rate",
+    limit: int = 10,
+    client: Optional[FXMacroDataClient] = None,
+) -> Dict[str, Any]:
+    client = client or FXMacroDataClient()
+    base = base.lower()
+    quote = quote.lower()
+    return {
+        "base_catalogue": client.data_catalogue(base),
+        "quote_catalogue": client.data_catalogue(quote),
+        "base_calendar": client.calendar(base, limit=limit),
+        "quote_calendar": client.calendar(quote, limit=limit),
+        "base_announcements": client.announcements(base, indicator, limit=limit),
+        "quote_announcements": client.announcements(quote, indicator, limit=limit),
+        "forex": client.forex(base, quote, limit=limit),
+    }

--- a/fast_trade/fxmacrodata.py
+++ b/fast_trade/fxmacrodata.py
@@ -12,7 +12,7 @@ Params = Mapping[str, Any]
 class FXMacroDataClient:
     """REST client for macro, FX, COT, commodity, and session data."""
 
-    DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1/"
+    DEFAULT_BASE_URL = "https://api.fxmacrodata.com/v1/"
 
     def __init__(
         self,
@@ -36,13 +36,14 @@ class FXMacroDataClient:
         timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
         query = dict(params or {})
-        if self.api_key:
-            query["api_key"] = self.api_key
         url = urllib.parse.urljoin(self.base_url, path.lstrip("/"))
         if query:
             url = url + "?" + urllib.parse.urlencode(query)
 
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        headers = {"Accept": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        req = urllib.request.Request(url, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout or self.timeout) as resp:
                 payload = resp.read().decode("utf-8")
@@ -129,8 +130,8 @@ def build_macro_context(
     return {
         "base_catalogue": client.data_catalogue(base),
         "quote_catalogue": client.data_catalogue(quote),
-        "base_calendar": client.calendar(base, limit=limit),
-        "quote_calendar": client.calendar(quote, limit=limit),
+        "base_calendar": client.calendar(base, indicator=indicator),
+        "quote_calendar": client.calendar(quote, indicator=indicator),
         "base_announcements": client.announcements(base, indicator, limit=limit),
         "quote_announcements": client.announcements(quote, indicator, limit=limit),
         "forex": client.forex(base, quote, limit=limit),

--- a/fast_trade/mcp_server.py
+++ b/fast_trade/mcp_server.py
@@ -6,6 +6,7 @@ import sys
 from typing import List, Optional
 
 from fast_trade.archive.cli import get_assets
+from fast_trade.fxmacrodata import build_macro_context
 from fast_trade.portfolio import load_state, portfolio_paths
 
 try:
@@ -173,6 +174,21 @@ def tail_log(kind: str, identifier: str, lines: int = 200) -> List[str]:
     return data
 
 
+def fxmacrodata_macro_context(
+    base: str,
+    quote: str = "usd",
+    indicator: str = "policy_rate",
+    limit: int = 10,
+) -> dict:
+    """Fetch FXMacroData macro context for an FX pair."""
+    return build_macro_context(
+        base=base,
+        quote=quote,
+        indicator=indicator,
+        limit=limit,
+    )
+
+
 @mcp.resource("fast-trade://version")
 def version_resource() -> str:
     """Return package version from pyproject."""
@@ -197,6 +213,7 @@ def main() -> None:
     mcp.tool(portfolio_stop)
     mcp.tool(portfolio_status)
     mcp.tool(tail_log)
+    mcp.tool(fxmacrodata_macro_context)
     mcp.run()
 
 

--- a/test/test_fxmacrodata.py
+++ b/test/test_fxmacrodata.py
@@ -1,0 +1,80 @@
+import io
+from unittest import mock
+from urllib.error import HTTPError
+
+import pytest
+
+from fast_trade.fxmacrodata import FXMacroDataClient, build_macro_context
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+
+def test_request_uses_canonical_host_query_encoding_and_header_auth():
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["api_key"] = request.get_header("X-api-key")
+        captured["timeout"] = timeout
+        return FakeResponse(b'{"data": []}')
+
+    with mock.patch("fast_trade.fxmacrodata.urllib.request.urlopen", side_effect=fake_urlopen):
+        result = FXMacroDataClient(api_key="test-key", timeout=12).calendar(
+            "USD", indicator="policy rate", start_date="2024-01-01"
+        )
+
+    assert result == {"data": []}
+    assert captured == {
+        "url": "https://api.fxmacrodata.com/v1/calendar/usd?indicator=policy+rate&start_date=2024-01-01",
+        "api_key": "test-key",
+        "timeout": 12,
+    }
+
+
+def test_constructor_reads_api_key_from_environment(monkeypatch):
+    monkeypatch.setenv("FXMACRODATA_API_KEY", "environment-key")
+
+    assert FXMacroDataClient().api_key == "environment-key"
+    assert FXMacroDataClient(api_key="constructor-key").api_key == "constructor-key"
+
+
+def test_request_wraps_http_errors():
+    error = HTTPError("https://example.test", 401, "Unauthorized", {}, io.BytesIO(b"invalid key"))
+
+    with mock.patch("fast_trade.fxmacrodata.urllib.request.urlopen", side_effect=error):
+        with pytest.raises(RuntimeError, match="HTTP 401: invalid key"):
+            FXMacroDataClient().data_catalogue("USD")
+
+
+def test_build_macro_context_filters_calendars_and_does_not_limit_them():
+    calls = []
+
+    class StubClient:
+        def data_catalogue(self, currency):
+            calls.append(("data_catalogue", currency, {}))
+            return {"currency": currency}
+
+        def calendar(self, currency, **params):
+            calls.append(("calendar", currency, params))
+            return {"currency": currency, "params": params}
+
+        def announcements(self, currency, indicator, **params):
+            calls.append(("announcements", currency, {"indicator": indicator, **params}))
+            return {"currency": currency}
+
+        def forex(self, base, quote, **params):
+            calls.append(("forex", f"{base}/{quote}", params))
+            return {"pair": f"{base}/{quote}"}
+
+    context = build_macro_context("EUR", "USD", indicator="inflation", limit=5, client=StubClient())
+
+    assert context["base_calendar"]["params"] == {"indicator": "inflation"}
+    assert context["quote_calendar"]["params"] == {"indicator": "inflation"}
+    assert ("announcements", "eur", {"indicator": "inflation", "limit": 5}) in calls
+    assert ("forex", "eur/usd", {"limit": 5}) in calls

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,5 +1,4 @@
 import json
-import os
 from types import SimpleNamespace
 
 import fast_trade.mcp_server as mcp_server
@@ -58,3 +57,18 @@ def test_ft_command_str_runs(monkeypatch):
     assert res["returncode"] == 0
     assert "fast_trade.cli" in " ".join(res["command"].split())
     assert calls["cmd"][0].endswith("python") or "python" in calls["cmd"][0]
+
+
+def test_fxmacrodata_macro_context_forwards_arguments(monkeypatch):
+    captured = {}
+
+    def fake_build_macro_context(**kwargs):
+        captured.update(kwargs)
+        return {"base_calendar": {"data": []}}
+
+    monkeypatch.setattr(mcp_server, "build_macro_context", fake_build_macro_context)
+
+    result = mcp_server.fxmacrodata_macro_context("EUR", "USD", "inflation", limit=5)
+
+    assert result == {"base_calendar": {"data": []}}
+    assert captured == {"base": "EUR", "quote": "USD", "indicator": "inflation", "limit": 5}


### PR DESCRIPTION
## Summary
- add an FXMacroData REST client for macro, FX, COT, commodity, session, and sentiment data
- export the client and macro-context helper from fast_trade
- expose macro context as a FastMCP tool for the existing MCP server

## Validation
- python -m py_compile fast_trade\fxmacrodata.py fast_trade\mcp_server.py
- git diff --check