### PR TITLE
Fix CI failure in terminal follow-view coverage tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,8 +6,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
+    env:
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      VECLIB_MAXIMUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,13 +1,46 @@
 """Shared fixtures for CLI and terminal tests."""
 
-import json
+import multiprocessing as mp
 import os
+import sys
 from pathlib import Path
 
 import pandas as pd
 import pytest
 import yaml
 from typer.testing import CliRunner
+
+_SESSION_EXITSTATUS = None
+
+
+def pytest_configure(config):
+    # Terminal coverage starts threads before chunked backtests fork.
+    # Spawn avoids corrupting native libs that later abort on interpreter exit.
+    try:
+        mp.set_start_method("spawn", force=True)
+    except RuntimeError:
+        pass
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    global _SESSION_EXITSTATUS
+    _SESSION_EXITSTATUS = int(exitstatus)
+
+
+def pytest_unconfigure(config):
+    # Runs after terminal reporting. Skip fragile C++/OpenBLAS atexit teardown;
+    # GitHub runners otherwise SIGABRT (exit 134) even when the suite is green.
+    if _SESSION_EXITSTATUS is None:
+        return
+    reporter = config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        tw = getattr(reporter, "_tw", None)
+        if tw is not None and hasattr(tw, "flush"):
+            tw.flush()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(_SESSION_EXITSTATUS)
 
 
 @pytest.fixture

--- a/test/test_cli_final_coverage.py
+++ b/test/test_cli_final_coverage.py
@@ -1099,26 +1099,18 @@ def test_terminal_live_page_with_history_render(
     archive_env, backtest_run, strategy_file, monkeypatch, sample_ohlcv
 ):
     _mock_tty(monkeypatch)
-    monkeypatch.delenv("FT_TERMINAL_SYNC_LIVE", raising=False)
+    # Sync live path avoids real Thread.start/_started races under pytest.
+    monkeypatch.setenv("FT_TERMINAL_SYNC_LIVE", "1")
+    monkeypatch.delenv("FT_TERMINAL_SYNC_STREAM", raising=False)
     run_id, _, _ = backtest_run
     (archive_env / "last_strategy_path.txt").write_text(str(strategy_file))
 
-    class _NoopTimer:
-        def __init__(self, *args, **kwargs):
-            pass
+    class _ImmediateTimer:
+        def __init__(self, delay, func, args=None, kwargs=None):
+            self._func = func
 
         def start(self):
-            return None
-
-    wait_calls = {"n": 0}
-    orig_wait = threading.Event.wait
-
-    def wait_side(self, timeout=None):
-        wait_calls["n"] += 1
-        if wait_calls["n"] >= 1:
-            self.set()
-            return True
-        return orig_wait(self, timeout)
+            self._func()
 
     cmd_iter = iter(["LIVE START", "LIVE", "Q"])
 
@@ -1133,8 +1125,7 @@ def test_terminal_live_page_with_history_render(
     session = mock.Mock()
     session.prompt.side_effect = prompt_side
     monkeypatch.setattr(cli_mod, "PromptSession", lambda **kw: session)
-    monkeypatch.setattr(cli_mod.threading, "Timer", _NoopTimer)
-    monkeypatch.setattr(threading.Event, "wait", wait_side)
+    monkeypatch.setattr(cli_mod.threading, "Timer", _ImmediateTimer)
     monkeypatch.setattr(cli_mod, "open_strat_file", lambda p: {"symbol": "BTC-USD", "freq": "1Min", "datapoints": []})
     monkeypatch.setattr(cli_mod, "_load_latest_ohlcv", lambda *a, **k: sample_ohlcv.head(10))
     monkeypatch.setattr(cli_mod, "prepare_df", lambda df, s: df)
@@ -1148,26 +1139,44 @@ def test_terminal_follow_view_loops_with_content(
     archive_env, backtest_run, strategy_file, monkeypatch, sample_ohlcv
 ):
     _mock_tty(monkeypatch)
-    monkeypatch.delenv("FT_TERMINAL_SYNC_LIVE", raising=False)
+    # Do not patch threading.Event.wait globally: that prematurely sets Thread._started
+    # and makes later is_alive() raise AssertionError in CPython.
+    monkeypatch.setenv("FT_TERMINAL_SYNC_LIVE", "1")
+    monkeypatch.delenv("FT_TERMINAL_SYNC_STREAM", raising=False)
     run_id, _, _ = backtest_run
     (archive_env / "last_strategy_path.txt").write_text(str(strategy_file))
 
-    class _NoopTimer:
-        def __init__(self, *args, **kwargs):
-            pass
+    class _ImmediateTimer:
+        def __init__(self, delay, func, args=None, kwargs=None):
+            self._func = func
+
+        def start(self):
+            self._func()
+
+    class _NoopWorkerThread:
+        def __init__(self, target=None, daemon=None, *args, **kwargs):
+            self._target = target
 
         def start(self):
             return None
 
-    wait_calls = {"n": 0}
-    orig_wait = threading.Event.wait
+        def is_alive(self):
+            return False
 
-    def wait_side(self, timeout=None):
-        wait_calls["n"] += 1
-        if wait_calls["n"] >= 1:
-            self.set()
-            return True
-        return orig_wait(self, timeout)
+        def join(self, timeout=None):
+            return None
+
+    def thread_factory(target=None, daemon=None, *args, **kwargs):
+        name = getattr(target, "__name__", "") if target else ""
+        if name in (
+            "_wait_enter",
+            "_wait_enter_live_view",
+            "_wait_enter_logs",
+            "_run_stream",
+            "_run_live",
+        ):
+            return _NoopWorkerThread(target=target, daemon=daemon)
+        return _terminal_thread_factory(target=target, daemon=daemon, *args, **kwargs)
 
     cmd_iter = iter(["STREAM START BTC-USD", "LIVE START", "LIVE VIEW", "STREAM VIEW", "Q"])
 
@@ -1182,9 +1191,8 @@ def test_terminal_follow_view_loops_with_content(
     session = mock.Mock()
     session.prompt.side_effect = prompt_side
     monkeypatch.setattr(cli_mod, "PromptSession", lambda **kw: session)
-    monkeypatch.setattr(cli_mod.threading, "Timer", _NoopTimer)
-    monkeypatch.setattr(threading.Event, "wait", wait_side)
-    monkeypatch.setattr(cli_mod.threading, "Thread", _terminal_thread_factory)
+    monkeypatch.setattr(cli_mod.threading, "Timer", _ImmediateTimer)
+    monkeypatch.setattr(cli_mod.threading, "Thread", thread_factory)
     monkeypatch.setattr(cli_mod.threading, "Event", lambda: _AutoStopEvent(stop_after=2))
     monkeypatch.setattr(cli_mod, "open_strat_file", lambda p: {"symbol": "BTC-USD", "freq": "1Min", "datapoints": []})
     monkeypatch.setattr(cli_mod, "_load_latest_ohlcv", lambda *a, **k: sample_ohlcv.head(10))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Master CI failed on `Python application` after the full-package coverage commit.

## Root causes
1. **Failing test:** `test_terminal_follow_view_loops_with_content` patched `threading.Event.wait` globally. That prematurely set `Thread._started`, so later `stream_thread.is_alive()` hit a CPython assertion and failed the suite.
2. **Teardown abort:** After all 741 tests passed, the runner aborted with `terminate called without an active exception` / exit 134 during native (OpenBLAS) cleanup. Coverage tests start threads before chunked backtests `fork()`, which exacerbates this on GitHub runners.

## Fixes
- Stop patching `Event.wait`; drive terminal live/follow coverage with sync live + noop worker threads + `_AutoStopEvent`.
- Force multiprocessing `spawn` in `test/conftest.py`, and `os._exit` after reporting to skip fragile C++ atexit teardown.
- Workflow: `fail-fast: false` and single-thread BLAS env vars.

## Testing
- Local: `741 passed`
- Explicit fail still returns non-zero with the `os._exit` hook
- Awaiting GitHub Actions on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5edd-c71e-74f5-9f0c-e8be999f8db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5edd-c71e-74f5-9f0c-e8be999f8db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

