### PR TITLE
Add walk-forward ML evaluation vs baselines

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -21,6 +21,7 @@ Current surface area for `fast-trade` `2.1.0`. Use this table to see what exists
 | Paper portfolio stop | `ft portfolio stop` | `portfolio_stop` | 2.0.0 | |
 | HMM forecast screen | `ft screen hmm` | `screen_hmm`, `hmm_screen` | 2.1.0 | `screen_hmm` wraps CLI; `hmm_screen` returns JSON |
 | Classifier → `ml_signal` example | `examples/ml_classifier_backtest.py` | — | 2.1.x | Library helpers in `fast_trade.ml.classifier`; uses `column` datapoint |
+| Walk-forward ML vs baselines | `examples/ml_walk_forward.py` | — | 2.1.x | `fast_trade.ml.walk_forward`; rolling OOS folds vs buy&hold / RSI / random |
 | FXMacroData context | — | `fxmacrodata_macro_context` | 2.1.0 | API helper, no dedicated CLI |
 | List strategy files | — | `list_strategies` | stable | Helper over `ft_archive/strategies/` |
 | Escape hatch | any `ft ...` | `ft_command`, `ft_command_str` | stable | Raw CLI passthrough |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -211,6 +211,18 @@ python examples/ml_classifier_backtest.py --symbol BTCUSDT --exchange binanceus
 
 Helpers live in `fast_trade/ml/classifier.py`. The strategy shape is documented in `examples/ml_classifier_strategy.yml` (uses the `column` datapoint transformer for precomputed signals).
 
+### Walk-forward evaluation
+
+Judge whether the classifier beats simple baselines on rolling out-of-sample windows (buy & hold, RSI, random entry):
+
+```bash
+python examples/ml_walk_forward.py --synthetic
+python examples/ml_walk_forward.py --symbol BTCUSDT --exchange binanceus \
+  --start 2024-01-01 --stop 2025-01-01 --train-size 400 --test-size 100
+```
+
+API: `fast_trade.ml.walk_forward.walk_forward_evaluate`. Each fold trains only on the train window, predicts `ml_signal` on the test window, then backtests that holdout. Treat this as research scaffolding — require stable OOS AUC and baseline wins before trusting signals.
+
 ## Important Files
 
 - `README.md`: top-level project overview
@@ -221,6 +233,7 @@ Helpers live in `fast_trade/ml/classifier.py`. The strategy shape is documented 
 - `hmm_screen_example.yml`: example config for `ft screen hmm`
 - `examples/ml_classifier_backtest.py`: classifier → `ml_signal` → backtest demo
 - `examples/ml_classifier_strategy.yml`: enter/exit pattern for classifier signals
+- `examples/ml_walk_forward.py`: walk-forward folds vs buy&hold / RSI / random
 
 ## Tips
 

--- a/examples/ml_walk_forward.py
+++ b/examples/ml_walk_forward.py
@@ -1,0 +1,125 @@
+"""Walk-forward classifier evaluation vs buy-and-hold / RSI / random baselines.
+
+Usage:
+  python examples/ml_walk_forward.py --synthetic
+  python examples/ml_walk_forward.py --symbol BTCUSDT --exchange binanceus \\
+      --start 2024-01-01 --stop 2025-01-01
+
+Requires archive data unless ``--synthetic`` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pprint
+import sys
+
+import numpy as np
+import pandas as pd
+
+from fast_trade.archive.db_helpers import get_kline
+from fast_trade.ml.walk_forward import report_to_frame, walk_forward_evaluate
+
+
+def _synthetic_ohlcv(rows: int = 1200, seed: int = 7, freq: str = "1h") -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2024-01-01", periods=rows, freq=freq, tz="UTC")
+    rets = rng.normal(0.0003, 0.01, size=rows)
+    close = 100 * np.cumprod(1.0 + rets)
+    high = close * (1.0 + rng.uniform(0.0, 0.008, size=rows))
+    low = close * (1.0 - rng.uniform(0.0, 0.008, size=rows))
+    open_ = np.roll(close, 1)
+    open_[0] = close[0]
+    volume = rng.uniform(100.0, 1000.0, size=rows)
+    return pd.DataFrame(
+        {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
+        index=idx,
+    )
+
+
+def _load_archive(symbol: str, exchange: str, start: str, stop: str, freq: str) -> pd.DataFrame:
+    df = get_kline(symbol, exchange, start_date=start, end_date=stop, freq=freq)
+    if df is None or df.empty:
+        raise SystemExit(
+            f"No archive data for {exchange}:{symbol}. "
+            f"Download first or pass --synthetic.\n"
+            f"  ft download {symbol} {exchange} --start {start} --end {stop}"
+        )
+    return df
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--exchange", default="binanceus")
+    parser.add_argument("--freq", default="1h")
+    parser.add_argument("--start", default="2024-01-01")
+    parser.add_argument("--stop", default="2025-01-01")
+    parser.add_argument("--train-size", type=int, default=400)
+    parser.add_argument("--test-size", type=int, default=100)
+    parser.add_argument("--step-size", type=int, default=None)
+    parser.add_argument("--horizon", type=int, default=5)
+    parser.add_argument("--threshold", type=float, default=0.01)
+    parser.add_argument("--comission", type=float, default=0.01)
+    parser.add_argument("--no-ta", action="store_true", help="Disable TA datapoint features")
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Use generated OHLCV instead of the local archive",
+    )
+    args = parser.parse_args(argv)
+
+    if args.synthetic:
+        # Enough bars for several folds with default train/test sizes.
+        rows = max(args.train_size + args.test_size * 4, 900)
+        df = _synthetic_ohlcv(rows=rows, freq=args.freq)
+        print(f"Using synthetic OHLCV: {len(df)} rows @ {args.freq}")
+    else:
+        df = _load_archive(args.symbol, args.exchange, args.start, args.stop, args.freq)
+        print(
+            f"Loaded {args.exchange}:{args.symbol} "
+            f"{df.index.min()} → {df.index.max()} ({len(df)} rows)"
+        )
+
+    report = walk_forward_evaluate(
+        df,
+        train_size=args.train_size,
+        test_size=args.test_size,
+        step_size=args.step_size,
+        horizon=args.horizon,
+        threshold=args.threshold,
+        use_ta=not args.no_ta,
+        freq=args.freq,
+        comission=args.comission,
+    )
+
+    frame = report_to_frame(report)
+    print("\nWalk-forward folds")
+    print(
+        frame[
+            [
+                "fold",
+                "test_rows",
+                "test_roc_auc",
+                "ml_return_perc",
+                "buy_hold_return_perc",
+                "rsi_return_perc",
+                "random_return_perc",
+                "beats_buy_hold",
+                "beats_rsi",
+            ]
+        ].to_string(index=False)
+    )
+
+    print("\nAggregate")
+    pprint.pprint(report.aggregate)
+    print(f"\nFeatures ({len(report.feature_columns)}): {report.feature_columns}")
+    print(
+        f"Label: forward {report.label_horizon} bars > {report.label_threshold:.2%} | "
+        f"windows train={report.train_size} test={report.test_size} step={report.step_size}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fast_trade/ml/walk_forward.py
+++ b/fast_trade/ml/walk_forward.py
@@ -1,0 +1,487 @@
+"""Walk-forward evaluation for classifier signals vs simple baselines.
+
+Trains only on each fold's train window, predicts ``ml_signal`` on the test
+window, backtests that holdout, and compares against buy-and-hold, RSI, and
+random-entry baselines on the same OOS bars.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.metrics import accuracy_score, roc_auc_score
+
+from fast_trade.build_data_frame import apply_transformers_to_dataframe
+from fast_trade.ml.classifier import (
+    attach_ml_signal,
+    build_classifier_features,
+    default_classifier_strategy,
+    label_forward_return,
+    predict_ml_signal,
+)
+from fast_trade.run_backtest import run_backtest
+
+
+DEFAULT_TA_DATAPOINTS: List[Dict[str, Any]] = [
+    {"name": "rsi", "transformer": "rsi", "args": [14]},
+    {"name": "ema_fast", "transformer": "ema", "args": [12]},
+    {"name": "ema_slow", "transformer": "ema", "args": [26]},
+    {"name": "atr", "transformer": "atr", "args": [14]},
+]
+
+
+@dataclass(frozen=True)
+class FoldWindow:
+    fold: int
+    train_index: pd.Index
+    test_index: pd.Index
+
+    @property
+    def train_start(self) -> Any:
+        return self.train_index[0]
+
+    @property
+    def train_end(self) -> Any:
+        return self.train_index[-1]
+
+    @property
+    def test_start(self) -> Any:
+        return self.test_index[0]
+
+    @property
+    def test_end(self) -> Any:
+        return self.test_index[-1]
+
+
+@dataclass
+class FoldMetrics:
+    fold: int
+    train_rows: int
+    test_rows: int
+    train_start: str
+    train_end: str
+    test_start: str
+    test_end: str
+    test_accuracy: Optional[float]
+    test_roc_auc: Optional[float]
+    ml_return_perc: float
+    ml_num_trades: int
+    ml_sharpe_ratio: float
+    buy_hold_return_perc: float
+    rsi_return_perc: float
+    rsi_num_trades: int
+    random_return_perc: float
+    random_num_trades: int
+    beats_buy_hold: bool
+    beats_rsi: bool
+    beats_random: bool
+
+
+@dataclass
+class WalkForwardReport:
+    folds: List[FoldMetrics]
+    feature_columns: List[str]
+    label_horizon: int
+    label_threshold: float
+    train_size: int
+    test_size: int
+    step_size: int
+    aggregate: Dict[str, Any] = field(default_factory=dict)
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+def iter_rolling_folds(
+    index: pd.Index,
+    *,
+    train_size: int,
+    test_size: int,
+    step_size: Optional[int] = None,
+) -> List[FoldWindow]:
+    """Build contiguous rolling train/test folds over ``index``."""
+    if train_size < 20:
+        raise ValueError("train_size must be >= 20")
+    if test_size < 5:
+        raise ValueError("test_size must be >= 5")
+    step = step_size if step_size is not None else test_size
+    if step < 1:
+        raise ValueError("step_size must be >= 1")
+
+    n = len(index)
+    need = train_size + test_size
+    if n < need:
+        raise ValueError(f"Need at least {need} rows for one fold; got {n}")
+
+    folds: List[FoldWindow] = []
+    start = 0
+    fold_i = 0
+    while start + need <= n:
+        train_idx = index[start:start + train_size]
+        test_idx = index[start + train_size:start + need]
+        folds.append(FoldWindow(fold=fold_i, train_index=train_idx, test_index=test_idx))
+        fold_i += 1
+        start += step
+    return folds
+
+
+def _numeric_feature_columns(df: pd.DataFrame, exclude: Iterable[str]) -> List[str]:
+    skip = set(exclude)
+    cols: List[str] = []
+    for col in df.columns:
+        if col in skip:
+            continue
+        if pd.api.types.is_numeric_dtype(df[col]):
+            cols.append(col)
+    return cols
+
+
+def build_feature_matrix(
+    df: pd.DataFrame,
+    *,
+    use_ta: bool = True,
+    ta_datapoints: Optional[Sequence[Mapping[str, Any]]] = None,
+    include_basic: bool = True,
+    feature_columns: Optional[Sequence[str]] = None,
+) -> Tuple[pd.DataFrame, List[str]]:
+    """Build the feature matrix used across all walk-forward folds.
+
+    Indicators are computed once on the full frame (rolling TA is causal).
+    Labels still must be sliced so the horizon does not cross into the test
+    window during training.
+    """
+    required = {"open", "high", "low", "close", "volume"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Dataframe missing required columns: {sorted(missing)}")
+
+    parts: List[pd.DataFrame] = []
+    if include_basic:
+        parts.append(build_classifier_features(df))
+
+    if use_ta:
+        dps = [dict(dp) for dp in (ta_datapoints or DEFAULT_TA_DATAPOINTS)]
+        ohlcv = df[["open", "high", "low", "close", "volume"]].copy()
+        ta_df = apply_transformers_to_dataframe(ohlcv, dps)
+        # Drop raw OHLCV duplicates; keep only transformer outputs.
+        ta_only = ta_df.drop(columns=["open", "high", "low", "close", "volume"], errors="ignore")
+        parts.append(ta_only)
+
+    if not parts:
+        raise ValueError("No features selected; enable include_basic and/or use_ta")
+
+    features = pd.concat(parts, axis=1)
+    features = features.loc[:, ~features.columns.duplicated()]
+    features = features.replace([np.inf, -np.inf], np.nan)
+
+    if feature_columns is not None:
+        cols = list(feature_columns)
+        missing_cols = [c for c in cols if c not in features.columns]
+        if missing_cols:
+            raise ValueError(f"Unknown feature columns: {missing_cols}")
+    else:
+        cols = _numeric_feature_columns(
+            features, exclude={"open", "high", "low", "close", "volume", "y", "ml_signal"}
+        )
+        if not cols:
+            raise ValueError("No numeric feature columns available")
+
+    return features[cols], cols
+
+
+def buy_hold_return_perc(close: pd.Series) -> float:
+    if close.empty:
+        return 0.0
+    first = float(close.iloc[0])
+    last = float(close.iloc[-1])
+    if first == 0:
+        return 0.0
+    return float((last / first - 1.0) * 100.0)
+
+
+def _strategy_for_signal(
+    *,
+    signal_column: str = "ml_signal",
+    freq: str = "1h",
+    comission: float = 0.01,
+    **overrides: Any,
+) -> Dict[str, Any]:
+    strategy = default_classifier_strategy(
+        freq=freq, signal_column=signal_column, comission=comission, **overrides
+    )
+    strategy["start"] = None
+    strategy["stop"] = None
+    return strategy
+
+
+def _run_signal_backtest(
+    ohlcv: pd.DataFrame,
+    signal: pd.Series,
+    *,
+    freq: str,
+    comission: float,
+) -> Dict[str, Any]:
+    frame = attach_ml_signal(ohlcv, signal, column="ml_signal")
+    result = run_backtest(
+        _strategy_for_signal(freq=freq, comission=comission),
+        df=frame,
+    )
+    return result["summary"]
+
+
+def _rsi_baseline_summary(
+    ohlcv: pd.DataFrame,
+    *,
+    freq: str,
+    comission: float,
+) -> Dict[str, Any]:
+    strategy = {
+        "name": "rsi_baseline",
+        "freq": freq,
+        "comission": comission,
+        "any_enter": [],
+        "any_exit": [],
+        "datapoints": [{"name": "rsi", "transformer": "rsi", "args": [14]}],
+        "enter": [["rsi", "<", 30]],
+        "exit": [["rsi", ">", 70]],
+        "exit_on_end": True,
+        "base_balance": 1000,
+        "lot_size": 1,
+        "start": None,
+        "stop": None,
+    }
+    result = run_backtest(strategy, df=ohlcv.copy())
+    return result["summary"]
+
+
+def _random_signal(index: pd.Index, positive_rate: float, seed: int) -> pd.Series:
+    rate = float(np.clip(positive_rate, 0.0, 1.0))
+    rng = np.random.default_rng(seed)
+    values = (rng.random(len(index)) < rate).astype(int)
+    return pd.Series(values, index=index, name="ml_signal")
+
+
+def _safe_auc(y_true: np.ndarray, y_score: np.ndarray) -> Optional[float]:
+    if len(np.unique(y_true)) < 2:
+        return None
+    return float(roc_auc_score(y_true, y_score))
+
+
+def _summary_metrics(summary: Mapping[str, Any]) -> Tuple[float, int, float]:
+    return (
+        float(summary.get("return_perc") or 0.0),
+        int(summary.get("num_trades") or 0),
+        float(summary.get("sharpe_ratio") or 0.0),
+    )
+
+
+def walk_forward_evaluate(
+    df: pd.DataFrame,
+    *,
+    train_size: int = 400,
+    test_size: int = 100,
+    step_size: Optional[int] = None,
+    horizon: int = 5,
+    threshold: float = 0.01,
+    use_ta: bool = True,
+    ta_datapoints: Optional[Sequence[Mapping[str, Any]]] = None,
+    include_basic: bool = True,
+    feature_columns: Optional[Sequence[str]] = None,
+    freq: str = "1h",
+    comission: float = 0.01,
+    random_state: int = 42,
+    baselines: Sequence[str] = ("buy_hold", "rsi", "random"),
+) -> WalkForwardReport:
+    """Run rolling walk-forward evaluation with optional baselines.
+
+    Parameters
+    ----------
+    train_size / test_size / step_size:
+        Bar counts for rolling windows. ``step_size`` defaults to ``test_size``.
+    horizon / threshold:
+        Forward-return label: 1 when return over ``horizon`` bars > ``threshold``.
+    use_ta:
+        When True, append ``DEFAULT_TA_DATAPOINTS`` (or ``ta_datapoints``).
+    baselines:
+        Any of ``buy_hold``, ``rsi``, ``random``.
+    """
+    baseline_set = set(baselines)
+    unknown = baseline_set - {"buy_hold", "rsi", "random"}
+    if unknown:
+        raise ValueError(f"Unknown baselines: {sorted(unknown)}")
+
+    features, cols = build_feature_matrix(
+        df,
+        use_ta=use_ta,
+        ta_datapoints=ta_datapoints,
+        include_basic=include_basic,
+        feature_columns=feature_columns,
+    )
+    labels = label_forward_return(df["close"], horizon=horizon, threshold=threshold)
+
+    # Align to rows with complete features; labels may still be NaN near the end.
+    usable_feat = features.dropna()
+    if usable_feat.empty:
+        raise ValueError("No usable feature rows after dropping NaNs")
+
+    folds = iter_rolling_folds(
+        usable_feat.index,
+        train_size=train_size,
+        test_size=test_size,
+        step_size=step_size,
+    )
+
+    fold_metrics: List[FoldMetrics] = []
+    for window in folds:
+        # Drop train rows whose label looks past the train boundary into test.
+        train_label_ok = window.train_index[:-horizon] if horizon > 0 else window.train_index
+        train_idx = train_label_ok.intersection(usable_feat.index)
+        test_idx = window.test_index.intersection(usable_feat.index)
+
+        y_train_full = labels.reindex(train_idx)
+        train_mask = y_train_full.notna()
+        train_idx = train_idx[train_mask.to_numpy()]
+        if len(train_idx) < 20:
+            raise ValueError(f"Fold {window.fold}: too few labeled train rows ({len(train_idx)})")
+
+        x_train = usable_feat.loc[train_idx, cols]
+        y_train = labels.loc[train_idx].astype(int)
+        if y_train.nunique() < 2:
+            raise ValueError(
+                f"Fold {window.fold}: training labels must include both classes; loosen threshold"
+            )
+
+        x_test = usable_feat.loc[test_idx, cols]
+        y_test = labels.reindex(test_idx)
+
+        model = HistGradientBoostingClassifier(random_state=random_state + window.fold)
+        model.fit(x_train, y_train)
+        pred = predict_ml_signal(model, x_test, cols)
+
+        test_acc: Optional[float] = None
+        test_auc: Optional[float] = None
+        labeled_test = y_test.dropna()
+        if not labeled_test.empty:
+            pred_labeled = pred.reindex(labeled_test.index)
+            test_acc = float(accuracy_score(labeled_test.astype(int), pred_labeled))
+            if hasattr(model, "predict_proba"):
+                proba = model.predict_proba(usable_feat.loc[labeled_test.index, cols])[:, 1]
+                test_auc = _safe_auc(labeled_test.astype(int).to_numpy(), proba)
+
+        ohlcv_test = df.loc[test_idx, ["open", "high", "low", "close", "volume"]]
+        ml_summary = _run_signal_backtest(
+            ohlcv_test, pred, freq=freq, comission=comission
+        )
+        ml_ret, ml_trades, ml_sharpe = _summary_metrics(ml_summary)
+
+        bh_ret = (
+            buy_hold_return_perc(ohlcv_test["close"])
+            if "buy_hold" in baseline_set
+            else 0.0
+        )
+
+        if "rsi" in baseline_set:
+            rsi_summary = _rsi_baseline_summary(
+                ohlcv_test, freq=freq, comission=comission
+            )
+            rsi_ret, rsi_trades, _ = _summary_metrics(rsi_summary)
+        else:
+            rsi_ret, rsi_trades = 0.0, 0
+
+        if "random" in baseline_set:
+            pos_rate = float(pred.mean()) if len(pred) else 0.0
+            rand_sig = _random_signal(test_idx, pos_rate, seed=random_state + 1000 + window.fold)
+            rand_summary = _run_signal_backtest(
+                ohlcv_test, rand_sig, freq=freq, comission=comission
+            )
+            rand_ret, rand_trades, _ = _summary_metrics(rand_summary)
+        else:
+            rand_ret, rand_trades = 0.0, 0
+
+        fold_metrics.append(
+            FoldMetrics(
+                fold=window.fold,
+                train_rows=len(train_idx),
+                test_rows=len(test_idx),
+                train_start=str(window.train_start),
+                train_end=str(window.train_end),
+                test_start=str(window.test_start),
+                test_end=str(window.test_end),
+                test_accuracy=test_acc,
+                test_roc_auc=test_auc,
+                ml_return_perc=ml_ret,
+                ml_num_trades=ml_trades,
+                ml_sharpe_ratio=ml_sharpe,
+                buy_hold_return_perc=bh_ret,
+                rsi_return_perc=rsi_ret,
+                rsi_num_trades=rsi_trades,
+                random_return_perc=rand_ret,
+                random_num_trades=rand_trades,
+                beats_buy_hold=ml_ret > bh_ret,
+                beats_rsi=ml_ret > rsi_ret,
+                beats_random=ml_ret > rand_ret,
+            )
+        )
+
+    ml_returns = [f.ml_return_perc for f in fold_metrics]
+    aucs = [f.test_roc_auc for f in fold_metrics if f.test_roc_auc is not None]
+    aggregate = {
+        "n_folds": len(fold_metrics),
+        "median_ml_return_perc": float(np.median(ml_returns)) if ml_returns else 0.0,
+        "mean_ml_return_perc": float(np.mean(ml_returns)) if ml_returns else 0.0,
+        "median_buy_hold_return_perc": float(
+            np.median([f.buy_hold_return_perc for f in fold_metrics])
+        ),
+        "median_rsi_return_perc": float(np.median([f.rsi_return_perc for f in fold_metrics])),
+        "median_random_return_perc": float(
+            np.median([f.random_return_perc for f in fold_metrics])
+        ),
+        "median_test_roc_auc": float(np.median(aucs)) if aucs else None,
+        "pct_folds_beat_buy_hold": float(
+            np.mean([f.beats_buy_hold for f in fold_metrics]) * 100.0
+        ),
+        "pct_folds_beat_rsi": float(np.mean([f.beats_rsi for f in fold_metrics]) * 100.0),
+        "pct_folds_beat_random": float(
+            np.mean([f.beats_random for f in fold_metrics]) * 100.0
+        ),
+        "total_ml_trades": int(sum(f.ml_num_trades for f in fold_metrics)),
+    }
+
+    return WalkForwardReport(
+        folds=fold_metrics,
+        feature_columns=cols,
+        label_horizon=horizon,
+        label_threshold=threshold,
+        train_size=train_size,
+        test_size=test_size,
+        step_size=step_size if step_size is not None else test_size,
+        aggregate=aggregate,
+        extras={"baselines": sorted(baseline_set), "freq": freq, "comission": comission},
+    )
+
+
+def report_to_frame(report: WalkForwardReport) -> pd.DataFrame:
+    """Convert fold metrics to a flat DataFrame for printing or CSV."""
+    rows = []
+    for f in report.folds:
+        rows.append(
+            {
+                "fold": f.fold,
+                "test_start": f.test_start,
+                "test_end": f.test_end,
+                "test_rows": f.test_rows,
+                "test_accuracy": f.test_accuracy,
+                "test_roc_auc": f.test_roc_auc,
+                "ml_return_perc": f.ml_return_perc,
+                "ml_num_trades": f.ml_num_trades,
+                "buy_hold_return_perc": f.buy_hold_return_perc,
+                "rsi_return_perc": f.rsi_return_perc,
+                "random_return_perc": f.random_return_perc,
+                "beats_buy_hold": f.beats_buy_hold,
+                "beats_rsi": f.beats_rsi,
+                "beats_random": f.beats_random,
+            }
+        )
+    return pd.DataFrame(rows)

--- a/test/test_walk_forward.py
+++ b/test/test_walk_forward.py
@@ -1,0 +1,198 @@
+"""Tests for walk-forward classifier evaluation."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from fast_trade.ml.walk_forward import (
+    build_feature_matrix,
+    buy_hold_return_perc,
+    iter_rolling_folds,
+    report_to_frame,
+    walk_forward_evaluate,
+)
+
+
+def _synthetic_ohlcv(rows: int = 800, seed: int = 3, freq: str = "1h") -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2024-01-01", periods=rows, freq=freq, tz="UTC")
+    rets = rng.normal(0.0004, 0.012, size=rows)
+    close = 80 * np.cumprod(1.0 + rets)
+    high = close * (1.0 + rng.uniform(0.0, 0.01, size=rows))
+    low = close * (1.0 - rng.uniform(0.0, 0.01, size=rows))
+    open_ = np.roll(close, 1)
+    open_[0] = close[0]
+    volume = rng.uniform(50.0, 400.0, size=rows)
+    return pd.DataFrame(
+        {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
+        index=idx,
+    )
+
+
+def test_iter_rolling_folds_shapes():
+    idx = pd.date_range("2024-01-01", periods=100, freq="h")
+    folds = iter_rolling_folds(idx, train_size=40, test_size=10, step_size=10)
+    assert len(folds) == 6
+    assert len(folds[0].train_index) == 40
+    assert len(folds[0].test_index) == 10
+    assert folds[0].train_start == idx[0]
+    assert folds[0].test_end == idx[49]
+
+
+def test_iter_rolling_folds_validation():
+    idx = pd.date_range("2024-01-01", periods=30, freq="h")
+    with pytest.raises(ValueError, match="train_size"):
+        iter_rolling_folds(idx, train_size=10, test_size=5)
+    with pytest.raises(ValueError, match="test_size"):
+        iter_rolling_folds(idx, train_size=20, test_size=2)
+    with pytest.raises(ValueError, match="step_size"):
+        iter_rolling_folds(idx, train_size=20, test_size=5, step_size=0)
+    with pytest.raises(ValueError, match="Need at least"):
+        iter_rolling_folds(idx, train_size=20, test_size=20)
+
+
+def test_build_feature_matrix_basic_and_ta():
+    df = _synthetic_ohlcv(rows=120)
+    features, cols = build_feature_matrix(df, use_ta=True, include_basic=True)
+    assert "ret_1" in cols
+    assert "rsi" in cols
+    assert "ema_fast" in cols
+    assert len(features) == len(df)
+
+    with pytest.raises(ValueError, match="missing required"):
+        build_feature_matrix(df.drop(columns=["volume"]))
+    with pytest.raises(ValueError, match="Unknown feature"):
+        build_feature_matrix(df, feature_columns=["nope"])
+    with pytest.raises(ValueError, match="No features selected"):
+        build_feature_matrix(df, use_ta=False, include_basic=False)
+
+
+def test_buy_hold_return_perc():
+    s = pd.Series([100.0, 110.0])
+    assert buy_hold_return_perc(s) == pytest.approx(10.0)
+    assert buy_hold_return_perc(pd.Series(dtype=float)) == 0.0
+    assert buy_hold_return_perc(pd.Series([0.0, 1.0])) == 0.0
+
+
+def test_walk_forward_evaluate_synthetic():
+    df = _synthetic_ohlcv(rows=900)
+    report = walk_forward_evaluate(
+        df,
+        train_size=300,
+        test_size=80,
+        step_size=80,
+        horizon=5,
+        threshold=0.0,
+        use_ta=True,
+        comission=0.0,
+        random_state=1,
+    )
+    assert report.aggregate["n_folds"] >= 2
+    assert len(report.folds) == report.aggregate["n_folds"]
+    assert report.folds[0].test_rows == 80
+    assert "median_ml_return_perc" in report.aggregate
+    frame = report_to_frame(report)
+    assert list(frame["fold"]) == list(range(len(report.folds)))
+    assert "beats_buy_hold" in frame.columns
+
+
+def test_walk_forward_unknown_baseline_and_no_ta():
+    df = _synthetic_ohlcv(rows=700)
+    with pytest.raises(ValueError, match="Unknown baselines"):
+        walk_forward_evaluate(df, baselines=("buy_hold", "magic"), train_size=300, test_size=80)
+
+    report = walk_forward_evaluate(
+        df,
+        train_size=300,
+        test_size=80,
+        step_size=200,
+        horizon=5,
+        threshold=0.0,
+        use_ta=False,
+        include_basic=True,
+        baselines=("buy_hold",),
+        comission=0.0,
+        random_state=2,
+    )
+    assert report.aggregate["n_folds"] >= 1
+    assert report.extras["baselines"] == ["buy_hold"]
+    # RSI/random skipped → zeros
+    assert report.folds[0].rsi_num_trades == 0
+    assert report.folds[0].random_num_trades == 0
+
+
+def test_walk_forward_rejects_single_class_labels():
+    df = _synthetic_ohlcv(rows=600)
+    with pytest.raises(ValueError, match="both classes"):
+        walk_forward_evaluate(
+            df,
+            train_size=300,
+            test_size=80,
+            step_size=80,
+            horizon=5,
+            threshold=50.0,
+            use_ta=False,
+            comission=0.0,
+        )
+
+
+def test_numeric_feature_skip_and_empty(monkeypatch):
+    from fast_trade.ml import walk_forward as wf
+
+    mixed = pd.DataFrame(
+        {
+            "a": [1.0, 2.0],
+            "b": ["x", "y"],
+            "ml_signal": [0, 1],
+        }
+    )
+    cols = wf._numeric_feature_columns(mixed, exclude={"ml_signal"})
+    assert cols == ["a"]
+
+    df = _synthetic_ohlcv(rows=120)
+    monkeypatch.setattr(wf, "_numeric_feature_columns", lambda *a, **k: [])
+    with pytest.raises(ValueError, match="No numeric feature"):
+        wf.build_feature_matrix(df, use_ta=False, include_basic=True)
+
+
+def test_safe_auc_single_class():
+    from fast_trade.ml.walk_forward import _safe_auc
+
+    assert _safe_auc(np.array([1, 1, 1]), np.array([0.1, 0.2, 0.3])) is None
+    assert _safe_auc(np.array([0, 1]), np.array([0.1, 0.9])) == pytest.approx(1.0)
+
+
+def test_walk_forward_empty_features_and_short_train(monkeypatch):
+    from fast_trade.ml import walk_forward as wf
+
+    df = _synthetic_ohlcv(rows=500)
+
+    class _Empty:
+        def dropna(self):
+            return pd.DataFrame()
+
+        @property
+        def columns(self):
+            return pd.Index(["ret_1"])
+
+    monkeypatch.setattr(
+        wf,
+        "build_feature_matrix",
+        lambda *a, **k: (_Empty(), ["ret_1"]),
+    )
+    with pytest.raises(ValueError, match="No usable feature"):
+        wf.walk_forward_evaluate(df, train_size=200, test_size=50, use_ta=False)
+
+    monkeypatch.undo()
+    # Huge horizon vs train window → too few labeled train rows
+    with pytest.raises(ValueError, match="too few labeled train"):
+        walk_forward_evaluate(
+            df,
+            train_size=40,
+            test_size=20,
+            step_size=20,
+            horizon=30,
+            threshold=0.0,
+            use_ta=False,
+            comission=0.0,
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the walk-forward research loop discussed for judging classifier signals before trusting them.

- `fast_trade/ml/walk_forward.py` — rolling train/test folds, TA + basic features, `HistGradientBoosting` trained per fold, OOS `ml_signal` backtests
- Baselines on the **same** OOS windows: buy & hold, RSI (`<30` / `>70`), random entry (matched positive rate)
- `examples/ml_walk_forward.py` — printable fold table + aggregate metrics
- Tests at 100% coverage on `walk_forward.py`
- Docs pointers in Getting Started / Features

Stacked on `cursor/ml-classifier-example-639f` (classifier → `ml_signal` plumbing from #45).

## How to try
```bash
python examples/ml_walk_forward.py --synthetic
python examples/ml_walk_forward.py --symbol BTCUSDT --exchange binanceus \
  --start 2024-01-01 --stop 2025-01-01 --train-size 400 --test-size 100
```

## Testing
- `python -m pytest test/test_walk_forward.py` (10 passed)
- `coverage report` → `walk_forward.py` 100%
- `flake8` clean on touched files
- Synthetic demo run attached in agent artifacts

## Note
Synthetic demo median OOS AUC ~0.53 and ML does not dominate RSI — expected. This PR is the evaluation harness, not a claim of edge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02719-fcf3-74f2-bb14-27a971e9639f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02719-fcf3-74f2-bb14-27a971e9639f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

